### PR TITLE
Handle numpy-style integral arguments in Fibonacci engine

### DIFF
--- a/fibkit-2.1.0/.gitignore
+++ b/fibkit-2.1.0/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+.pytest_cache/

--- a/fibkit-2.1.0/src/fibkit/core.py
+++ b/fibkit-2.1.0/src/fibkit/core.py
@@ -1,4 +1,5 @@
 import math
+import operator
 from dataclasses import dataclass
 from typing import Any, Dict, Generator, List, Tuple, Optional
 class FibonacciError(Exception): pass
@@ -11,6 +12,39 @@ class FibonacciEngine:
     def __init__(self, config: Optional[FibonacciConfig] = None):
         self.config = config or FibonacciConfig()
         self._small_fib_cache = self._precompute_small_fibonacci(1000)
+
+    @staticmethod
+    def _require_int(value: Any, *, desc: str) -> int:
+        if isinstance(value, bool):
+            raise FibonacciError(f"{desc} must be integer, got {type(value)}")
+        try:
+            return operator.index(value)
+        except TypeError:
+            raise FibonacciError(f"{desc} must be integer, got {type(value)}") from None
+
+    @staticmethod
+    def _require_non_negative(value: Any, *, desc: str) -> int:
+        if isinstance(value, bool):
+            raise FibonacciError(f"{desc} must be non-negative integer, got {value}")
+        try:
+            result = operator.index(value)
+        except TypeError:
+            raise FibonacciError(f"{desc} must be non-negative integer, got {value}") from None
+        if result < 0:
+            raise FibonacciError(f"{desc} must be non-negative integer, got {value}")
+        return result
+
+    @staticmethod
+    def _require_positive(value: Any, *, desc: str) -> int:
+        if isinstance(value, bool):
+            raise FibonacciError(f"{desc} must be positive integer, got {value}")
+        try:
+            result = operator.index(value)
+        except TypeError:
+            raise FibonacciError(f"{desc} must be positive integer, got {value}") from None
+        if result <= 0:
+            raise FibonacciError(f"{desc} must be positive integer, got {value}")
+        return result
     def _precompute_small_fibonacci(self, n: int) -> List[int]:
         if n < 2: return [0,1][:n+1]
         fibs=[0,1]
@@ -28,27 +62,34 @@ class FibonacciEngine:
         c=(a*((2*b-a)%m))%m; d=(a*a+b*b)%m
         return (d,(c+d)%m) if (n&1) else (c,d)
     def fibonacci(self,n:int)->int:
-        if not isinstance(n,int) or isinstance(n,bool): raise FibonacciError(f"Input must be integer, got {type(n)}")
+        n=self._require_int(n, desc="Input")
         if n<0: raise FibonacciError(f"Fibonacci undefined for negative n: {n}")
         if self.config.use_binet_for_small_n and n<=self.config.max_safe_binet: return self.fibonacci_binet(n)
         if n<len(self._small_fib_cache): return self._small_fib_cache[n]
         return self._fast_doubling(n)[0]
     def lucas(self,n:int)->int:
-        if not isinstance(n,int) or isinstance(n,bool): raise FibonacciError(f"Input must be integer, got {type(n)}")
+        n=self._require_int(n, desc="Input")
         if n<0: raise FibonacciError(f"Lucas undefined for negative n: {n}")
         f_n,f_np1=self._fast_doubling(n); return 2*f_np1 - f_n
     def fibonacci_binet(self,n:int)->int:
+        n=self._require_int(n, desc="Input")
         if n<0: raise FibonacciError(f"Fibonacci undefined for negative n: {n}")
-        if n>self.config.max_safe_binet: raise FibonacciError(f"Binet's formula unreliable for n > {self.config.max_safe_binet}")
+        if n>self.config.max_safe_binet:
+            raise FibonacciError(
+                f"Binet's formula unreliable for n > {self.config.max_safe_binet}"
+            )
         sqrt5=math.sqrt(5.0); phi=(1.0+sqrt5)/2.0; psi=(1.0-sqrt5)/2.0
         return int(round((phi**n-psi**n)/sqrt5))
     def fibonacci_sequence(self,limit:int)->Generator[int,None,None]:
-        if not isinstance(limit,int) or limit<0: raise FibonacciError(f"Limit must be non-negative integer, got {limit}")
-        if limit>self.config.sequence_limit: raise FibonacciError(f"Sequence limit {self.config.sequence_limit} exceeded: {limit}")
+        limit=self._require_non_negative(limit, desc="Limit")
+        if limit>self.config.sequence_limit:
+            raise FibonacciError(
+                f"Sequence limit {self.config.sequence_limit} exceeded: {limit}"
+            )
         a,b=0,1
         for _ in range(limit): yield a; a,b=b,a+b
     def generate_sequence(self,method:str="iterative",limit:int=20)->List[int]:
-        if not isinstance(limit,int) or limit<0: raise FibonacciError(f"Limit must be non-negative integer, got {limit}")
+        limit=self._require_non_negative(limit, desc="Limit")
         if method=="iterative": return list(self.fibonacci_sequence(limit))
         elif method=="fast_doubling": return [self._fast_doubling(i)[0] for i in range(limit)]
         elif method=="binet":
@@ -58,12 +99,12 @@ class FibonacciEngine:
             return seq
         else: raise FibonacciError(f"Unknown method '{method}'. Available: ['iterative','fast_doubling','binet']")
     def fibonacci_mod(self,n:int,m:int)->int:
-        if not isinstance(n,int) or isinstance(n,bool): raise FibonacciError(f"n must be integer, got {type(n)}")
+        n=self._require_int(n, desc="n")
         if n<0: raise FibonacciError(f"Fibonacci undefined for negative n: {n}")
-        if not isinstance(m,int) or m<=0: raise FibonacciError(f"modulus must be positive integer, got {m}")
+        m=self._require_positive(m, desc="modulus")
         return self._fast_doubling_mod(n,m)[0]
     def pisano_period(self,m:int)->int:
-        if not isinstance(m,int) or m<=0: raise FibonacciError(f"modulus must be positive integer, got {m}")
+        m=self._require_positive(m, desc="modulus")
         if m==1: return 1
         prev,curr=0,1
         for p in range(1,6*m+1):
@@ -71,6 +112,7 @@ class FibonacciEngine:
             if prev==0 and curr==1: return p
         raise FibonacciError("Pisano period search exceeded theoretical bound.")
     def analyze_fibonacci(self,n:int)->Dict[str,Any]:
+        n=self._require_int(n, desc="Input")
         if n<0: raise FibonacciError(f"Analysis undefined for negative n: {n}")
         fn=self.fibonacci(n); fn1=self.fibonacci(n+1)
         golden=(fn1/fn) if n>=2 else None

--- a/fibkit-2.1.0/tests/test_core.py
+++ b/fibkit-2.1.0/tests/test_core.py
@@ -43,6 +43,20 @@ def test_errors_and_guards():
         gen=eng.fibonacci_sequence(6); next(gen)
     with pytest.raises(FibonacciError): eng.fibonacci_binet(10**9)
 
+def test_accepts_indexable_integers_and_rejects_bool_modulus():
+    class Indexable:
+        def __init__(self, value): self.value=value
+        def __index__(self): return self.value
+
+    eng=FibonacciEngine()
+    assert eng.fibonacci(Indexable(10))==55
+    assert list(eng.fibonacci_sequence(Indexable(5)))==[0,1,1,2,3]
+    assert eng.fibonacci_mod(Indexable(8), Indexable(5))==eng.fibonacci_mod(8,5)
+    with pytest.raises(FibonacciError): eng.fibonacci(Indexable(-1))
+    with pytest.raises(FibonacciError): eng.fibonacci_mod(5, True)
+    with pytest.raises(FibonacciError): eng.generate_sequence(limit=True)
+    with pytest.raises(FibonacciError): FibonacciEngine().pisano_period(True)
+
 def test_big_perf_sanity():
     eng=FibonacciEngine(); f=eng.fibonacci(10_000)
     assert len(str(f))>=2090


### PR DESCRIPTION
## Summary
- allow FibonacciEngine methods to accept numpy integer inputs while still rejecting booleans
- centralize integer, non-negative, and positive argument validation with consistent error messages
- add regression coverage for indexable integer inputs and ensure bool arguments remain rejected
- ignore Python cache directories in version control

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d3bf23ec748333b36933e2ee2315a5