### PR TITLE
Enforce sequence limits for all generation methods

### DIFF
--- a/fibkit-2.1.0/src/fibkit/core.py
+++ b/fibkit-2.1.0/src/fibkit/core.py
@@ -90,6 +90,10 @@ class FibonacciEngine:
         for _ in range(limit): yield a; a,b=b,a+b
     def generate_sequence(self,method:str="iterative",limit:int=20)->List[int]:
         limit=self._require_non_negative(limit, desc="Limit")
+        if limit>self.config.sequence_limit:
+            raise FibonacciError(
+                f"Sequence limit {self.config.sequence_limit} exceeded: {limit}"
+            )
         if method=="iterative": return list(self.fibonacci_sequence(limit))
         elif method=="fast_doubling": return [self._fast_doubling(i)[0] for i in range(limit)]
         elif method=="binet":

--- a/fibkit-2.1.0/tests/test_core.py
+++ b/fibkit-2.1.0/tests/test_core.py
@@ -41,6 +41,10 @@ def test_errors_and_guards():
     with pytest.raises(FibonacciError): eng.fibonacci(True)
     with pytest.raises(FibonacciError):
         gen=eng.fibonacci_sequence(6); next(gen)
+    with pytest.raises(FibonacciError):
+        eng.generate_sequence("fast_doubling", 6)
+    with pytest.raises(FibonacciError):
+        eng.generate_sequence("binet", 6)
     with pytest.raises(FibonacciError): eng.fibonacci_binet(10**9)
 
 def test_accepts_indexable_integers_and_rejects_bool_modulus():


### PR DESCRIPTION
## Summary
- guard FibonacciEngine.generate_sequence with the configured sequence limit so all strategies respect it
- extend error coverage to ensure fast_doubling and binet sequence generation also raise when exceeding the limit

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d3cc3a7eb48333a6f536f3c5b4a8df