### PR TITLE
Add CI workflow and status badges

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,33 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+  workflow_dispatch:
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.9", "3.10", "3.11"]
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install "./fibkit-2.1.0[numpy]"
+          pip install pytest
+
+      - name: Run test suite
+        working-directory: fibkit-2.1.0
+        run: pytest

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # fibkit 2.1.0
 
+[![CI](https://github.com/yourname/fibkit/actions/workflows/ci.yml/badge.svg)](https://github.com/yourname/fibkit/actions/workflows/ci.yml)
+[![License: Apache-2.0](https://img.shields.io/badge/license-Apache--2.0-blue.svg)](LICENSE)
+
 Engineering-grade Fibonacci and Lucas toolkit for Python. **fibkit** combines mathematically sound implementations with production-friendly ergonomics so you can explore integer sequences, modular arithmetic, and general linear recurrences from a single package.
 
 ## Key features

--- a/fibkit-2.1.0/README.md
+++ b/fibkit-2.1.0/README.md
@@ -1,5 +1,8 @@
 # fibkit 2.1.0
 
+[![CI](https://github.com/yourname/fibkit/actions/workflows/ci.yml/badge.svg)](https://github.com/yourname/fibkit/actions/workflows/ci.yml)
+[![License: Apache-2.0](https://img.shields.io/badge/license-Apache--2.0-blue.svg)](../LICENSE)
+
 Engineering-grade Fibonacci and Lucas toolkit for Python. **fibkit** combines mathematically sound implementations with production-friendly ergonomics so you can explore integer sequences, modular arithmetic, and general linear recurrences from a single package.
 
 ## Key features


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow that installs the package and runs pytest on supported Python versions
- surface CI and Apache-2.0 license badges in both README files for quick project status visibility

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e0cde1bdb483339352f45e04c4d595