### PR TITLE
Fix CI badge links to correct repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # fibkit 2.1.0
 
-[![CI](https://github.com/yourname/fibkit/actions/workflows/ci.yml/badge.svg)](https://github.com/yourname/fibkit/actions/workflows/ci.yml)
+[![CI](https://github.com/SaridakisStamatisChristos/fibkit-2.1.0/actions/workflows/ci.yml/badge.svg)](https://github.com/SaridakisStamatisChristos/fibkit-2.1.0/actions/workflows/ci.yml)
 [![License: Apache-2.0](https://img.shields.io/badge/license-Apache--2.0-blue.svg)](LICENSE)
 
 Engineering-grade Fibonacci and Lucas toolkit for Python. **fibkit** combines mathematically sound implementations with production-friendly ergonomics so you can explore integer sequences, modular arithmetic, and general linear recurrences from a single package.

--- a/fibkit-2.1.0/README.md
+++ b/fibkit-2.1.0/README.md
@@ -1,6 +1,6 @@
 # fibkit 2.1.0
 
-[![CI](https://github.com/yourname/fibkit/actions/workflows/ci.yml/badge.svg)](https://github.com/yourname/fibkit/actions/workflows/ci.yml)
+[![CI](https://github.com/SaridakisStamatisChristos/fibkit-2.1.0/actions/workflows/ci.yml/badge.svg)](https://github.com/SaridakisStamatisChristos/fibkit-2.1.0/actions/workflows/ci.yml)
 [![License: Apache-2.0](https://img.shields.io/badge/license-Apache--2.0-blue.svg)](../LICENSE)
 
 Engineering-grade Fibonacci and Lucas toolkit for Python. **fibkit** combines mathematically sound implementations with production-friendly ergonomics so you can explore integer sequences, modular arithmetic, and general linear recurrences from a single package.


### PR DESCRIPTION
## Summary
- point the root README CI badge at the repository's actual workflow URL
- update the packaged README to reference the same workflow badge

## Testing
- not run (not needed)

------
https://chatgpt.com/codex/tasks/task_e_68e0cfb1484883338251c9ad1e3e3383